### PR TITLE
fix(rule): "no-doubled-conjunctive-particle-ga" request destination

### DIFF
--- a/lib/textlint-rule-preset-japanese.js
+++ b/lib/textlint-rule-preset-japanese.js
@@ -3,7 +3,7 @@
 module.exports = {
     "rules": {
         "max-ten": require("textlint-rule-max-ten"),
-        "no-doubled-conjunctive-particle-ga": require("textlint-rule-no-double-negative-ja"),
+        "no-doubled-conjunctive-particle-ga": require("textlint-rule-no-doubled-conjunctive-particle-ga"),
         "no-doubled-conjunction": require("textlint-rule-no-doubled-conjunction"),
         "no-double-negative-ja": require("textlint-rule-no-double-negative-ja"),
         "no-doubled-joshi": require("textlint-rule-no-doubled-joshi"),


### PR DESCRIPTION
このプリセット(ver 1.3.2)を使って
`今日は早朝から出発したが、定刻には間に合わなかったが、無事会場に到着した。`
のテキストを検証してもエラーにならなかったので、当該のルールの参照先を
`textlint-rule-no-doubled-conjunctive-particle-ga` に修正しました。
上記のリポジトリで行っているテストと同様のエラーが検知できています。